### PR TITLE
Skip constraints when config.where is set on tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ vars:
 packages:
   - package: Snowflake-Labs/dbt_constraints
     version: [">=0.3.0", "<0.4.0"]
-# <see https://github.com/Snowflake-Labs/dbt_constraints/releases/latest> for the latest version tag. 
+# <see https://github.com/Snowflake-Labs/dbt_constraints/releases/latest> for the latest version tag.
 # You can also pull the latest changes from Github with the following:
 #  - git: "https://github.com/Snowflake-Labs/dbt_constraints.git"
 #    revision: main
@@ -130,6 +130,8 @@ Generally, if you don't meet a requirement, tests are still executed but the con
 - The order of columns on a foreign key test must match between the FK columns and PK columns
 
 - The `foreign_key` test will ignore any rows with a null column, even if only one of two columns in a compound key is null. If you also want to ensure FK columns are not null, you should add standard `not_null` tests to your model.
+
+- Referential constraints must apply to all the rows in a table so any tests with a `config: where:` property will be skipped when creating constraints.
 
 ## Maintainers
 

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -66,6 +66,14 @@ models:
         tests:
           - unique
           - not_null
+      - name: o_orderkey_seq
+        description: "Sequence key based on orderkey"
+        tests:
+          # We are adding a where config to test that the constraint is skipped
+          - unique:
+              config:
+                where: "1 = 1"
+          - not_null
       - name: o_custkey
         tests:
           - not_null

--- a/macros/create_constraints.sql
+++ b/macros/create_constraints.sql
@@ -137,10 +137,12 @@
 {%- macro create_constraints_by_type(constraint_types, quote_columns) -%}
 
     {#- Loop through the results and find all tests that passed and match the constraint_types -#}
+    {#- Issue #2: added condition that the where config must be empty -#}
     {%- for res in results
         if res.status == "pass"
             and res.node.config.materialized == "test"
-            and res.node.test_metadata.name is in( constraint_types ) -%}
+            and res.node.test_metadata.name is in( constraint_types )
+            and res.node.config.where is none -%}
 
         {%- set test_model = res.node -%}
         {%- set test_parameters = test_model.test_metadata.kwargs -%}


### PR DESCRIPTION
Added filter, tests, and updated documents to reflect that tests with `where:` configs are excluded from constraint creation.