### PR TITLE
Fix to check test_metadata exists for test

### DIFF
--- a/integration_tests/tests/singlular_test.sql
+++ b/integration_tests/tests/singlular_test.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM {{ ref('dim_part') }}
+WHERE 1 = 2

--- a/macros/create_constraints.sql
+++ b/macros/create_constraints.sql
@@ -141,6 +141,7 @@
     {%- for res in results
         if res.status == "pass"
             and res.node.config.materialized == "test"
+            and res.node.test_metadata
             and res.node.test_metadata.name is in( constraint_types )
             and res.node.config.where is none -%}
 


### PR DESCRIPTION
Merging fix to allow for singular tests without the test_metadata attribute