### PR TITLE
Handling the Postgres identifier length limits

### DIFF
--- a/integration_tests/models/fact_order_line_longcol.sql
+++ b/integration_tests/models/fact_order_line_longcol.sql
@@ -1,0 +1,12 @@
+/*
+ Test
+dim_order_copy____________
+*/
+SELECT
+  l_orderkey as l_____________________orderkey,
+  l_linenumber as l___________________linenumber,
+  l_partkey as l______________________partkey,
+  l_suppkey l______________________suppkey,
+  integration_id as l_______________integration_id
+FROM
+{{ ref('fact_order_line') }} O

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -223,3 +223,35 @@ models:
 
   - name: dim_part_supplier_missing_con
     description: "Table is missing constraints to test FK won't be generated to it"
+
+  - name: fact_order_line_longcol
+    description: "Fact Order Lines with long column names"
+    columns:
+      - name: l_____________________orderkey
+        description: "FK to dim_orders and first key in PK"
+        tests:
+          - relationships:
+              to: ref('dim_orders')
+              field: o_orderkey
+      - name: l___________________linenumber
+        description: "Order Line Number and second key in PK"
+      - name: l_______________integration_id
+        description: "Concatenation of PK colums for the unique and not_null tests"
+        tests:
+          - unique
+          - not_null
+    tests:
+      # Demonstration that the primary_key test can accept multiple columns
+      - dbt_constraints.primary_key:
+          column_names:
+            - l_____________________orderkey
+            - l___________________linenumber
+      # Test multi-column FK
+      - dbt_constraints.foreign_key:
+          fk_column_names:
+            - l______________________partkey
+            - l______________________suppkey
+          pk_table_name: ref('dim_part_supplier')
+          pk_column_names:
+            - ps_partkey
+            - ps_suppkey

--- a/macros/postgres__create_constraints.sql
+++ b/macros/postgres__create_constraints.sql
@@ -1,16 +1,13 @@
 {# PostgreSQL specific implementation to create a primary key #}
-{%- macro postgres__create_primary_key(table_relation, column_names, verify_permissions, quote_columns=false) -%}    
+{%- macro postgres__create_primary_key(table_relation, column_names, verify_permissions, quote_columns=false) -%}
+    {%- set constraint_name = (table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper -%}
 
-    {% set constraint_name_query %}
-        select  {{ dbt_utils.hash( dbt_utils.string_literal( table_relation.identifier ~ "_" ~ column_names|join('_') ) )  }}
-    {%endset%}
-    
-    {% set results = run_query(constraint_name_query) %}
-    
-    {% if execute %}
-        {% set constraint_name = "PK_" ~ results.columns[0].values()[0] %}
-    {% else %}
-        {% set constraint_name = "" %}
+    {%- if constraint_name|length > 63 %}
+        {%- set constraint_name_query %}
+        select  'PK_' || md5( '{{ constraint_name }}' )::varchar as "constraint_name"
+        {%- endset -%}
+        {%- set results = run_query(constraint_name_query) -%}
+        {%- set constraint_name = results.columns[0].values()[0] -%}
     {% endif %}
 
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
@@ -40,20 +37,16 @@
 
 
 {# PostgreSQL specific implementation to create a unique key #}
-{%- macro postgres__create_unique_key(table_relation, column_names, verify_permissions, quote_columns=false) -%}   
+{%- macro postgres__create_unique_key(table_relation, column_names, verify_permissions, quote_columns=false) -%}
+    {%- set constraint_name = (table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK") | upper -%}
 
-    {%- set constraint_name_query %}
-        select  {{ dbt_utils.hash( dbt_utils.string_literal( table_relation.identifier ~ "_" ~ column_names|join('_') ) ) }}
-    {%endset%}   
-
-    {% set results = run_query(constraint_name_query) %}
-    
-    {% if execute %}
-        {% set constraint_name = "UK_" ~ results.columns[0].values()[0] %}
-    {% else %}
-        {% set constraint_name = "" %}
+    {%- if constraint_name|length > 63 %}
+        {%- set constraint_name_query %}
+        select  'UK_' || md5( '{{ constraint_name }}' )::varchar as "constraint_name"
+        {%- endset -%}
+        {%- set results = run_query(constraint_name_query) -%}
+        {%- set constraint_name = results.columns[0].values()[0] -%}
     {% endif %}
-
 
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
 
@@ -83,17 +76,14 @@
 
 {# PostgreSQL specific implementation to create a foreign key #}
 {%- macro postgres__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns=true) -%}
-    
-    {%- set constraint_name_query %}
-        select  {{ dbt_utils.hash( dbt_utils.string_literal( fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ) ) }}
-    {%endset%}
-    
-    {% set results = run_query(constraint_name_query) %}
-    
-    {% if execute %}
-        {% set constraint_name = "FK_" ~ results.columns[0].values()[0] %}
-    {% else %}
-        {% set constraint_name = "" %}
+    {%- set constraint_name = (fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper -%}
+
+    {%- if constraint_name|length > 63 %}
+        {%- set constraint_name_query %}
+        select  'FK_' || md5( '{{ constraint_name }}' )::varchar as "constraint_name"
+        {%- endset -%}
+        {%- set results = run_query(constraint_name_query) -%}
+        {%- set constraint_name = results.columns[0].values()[0] -%}
     {% endif %}
 
     {%- set fk_columns_csv = dbt_constraints.get_quoted_column_csv(fk_column_names, quote_columns) -%}

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=0.8.0", "<0.9.0"]


### PR DESCRIPTION
**Details:**

The existing implementation doesn’t properly shorten constraints to be within the 63 character limit that Postgres enforces.

`The system uses no more than NAMEDATALEN-1 bytes of an identifier; longer names can be written in commands, but they will be truncated. By default, NAMEDATALEN is 64 so the maximum identifier length is 63 bytes. If this limit is problematic, it can be raised by changing the NAMEDATALEN constant in src/include/pg_config_manual.h.`

Reference: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS

**Test results:**
<img width="1562" alt="image" src="https://user-images.githubusercontent.com/98582037/184115477-4a4197ef-fc71-4215-8f2d-90f271a88a64.png">

