### PR TITLE
Remove packages.yml

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,0 @@
-packages:
-  - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]


### PR DESCRIPTION
We haven't required dbt_utils in several releases and I should have removed the packages.yml earlier.