### PR TITLE
Moved not_null constraints first

### DIFF
--- a/macros/create_constraints.sql
+++ b/macros/create_constraints.sql
@@ -125,6 +125,9 @@
     {%- if execute and var('dbt_constraints_enabled', false) -%}
         {%- do log("Running dbt Constraints", info=true) -%}
 
+        {%- if 'not_null' in constraint_types -%}
+            {%- do dbt_constraints.create_constraints_by_type(['not_null'], quote_columns) -%}
+        {%- endif -%}
         {%- if 'primary_key' in constraint_types -%}
             {%- do dbt_constraints.create_constraints_by_type(['primary_key'], quote_columns) -%}
         {%- endif -%}
@@ -142,9 +145,6 @@
         {%- endif -%}
         {%- if 'relationships' in constraint_types -%}
             {%- do dbt_constraints.create_constraints_by_type(['relationships'], quote_columns) -%}
-        {%- endif -%}
-        {%- if 'not_null' in constraint_types -%}
-            {%- do dbt_constraints.create_constraints_by_type(['not_null'], quote_columns) -%}
         {%- endif -%}
 
         {%- do log("Finished dbt Constraints", info=true) -%}


### PR DESCRIPTION
Some databases are more sensitive to the order of running constraints and running not null constraints first appears to be the best option across DB.