### PR TITLE
CTE Column Names

### DIFF
--- a/macros/default__test_constraints.sql
+++ b/macros/default__test_constraints.sql
@@ -14,7 +14,7 @@ NOTE: This test is designed to implement the "primary key" as specified in ANSI 
 {#- This test will return for any duplicates and if any of the key columns is null -#}
 with validation_errors as (
     select
-        {{columns_csv}}, count(*)
+        {{columns_csv}}, count(*) as row_count
     from {{model}}
     group by {{columns_csv}}
     having count(*) > 1


### PR DESCRIPTION
Give "count(*)" the row_count column name. Some databases (rhymes with Mycrosoft Seequil Server) require CTE columns to have names