### PR TITLE
Excluding error_if and warn_if tests

### DIFF
--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -225,7 +225,7 @@ models:
               to: ref('supplier')
               field: s_suppkey
     tests:
-      - dbt_constraints.unique_key:
+      - dbt_constraints.primary_key:
           column_names:
             - ps_partkey
             - ps_suppkey

--- a/macros/create_constraints.sql
+++ b/macros/create_constraints.sql
@@ -172,6 +172,9 @@
             and res.node.config.materialized == "test"
             and res.node.test_metadata
             and res.node.test_metadata.name is in( constraint_types )
+            and res.failures == 0
+            and res.node.config.error_if == '!= 0'
+            and res.node.config.warn_if == '!= 0'
             and res.node.config.where is none -%}
 
         {%- set test_model = res.node -%}


### PR DESCRIPTION
A test needs to be either true or false in order to qualify to be a referential constraint. Similar to the filter on "where" config, I am now requiring error_if == '!= 0' and warn_if == '!= 0' to be included.