### PR TITLE
Added always_create_constraint config option

### DIFF
--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -152,19 +152,19 @@ models:
           column_name: o_orderkey
           config:
             severity: warn
-      # This constraint should be still generated because always_create_constraint=true
+      # This constraint can be generated if you uncomment always_create_constraint=true
       - dbt_constraints.unique_key:
           column_name: o_orderkey
           config:
             warn_if: ">= 5000"
             error_if: ">= 10000"
-            always_create_constraint: true
-      # This constraint should be still generated because always_create_constraint=true
+            # always_create_constraint: true
+      # This constraint can be generated if you uncomment always_create_constraint=true
       - dbt_constraints.unique_key:
           column_name: o_orderkey_seq
           config:
             severity: warn
-            always_create_constraint: true
+            # always_create_constraint: true
 
   - name: fact_order_line_missing_orders
     description: "Test that we do not create FK on failed tests"

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -147,14 +147,24 @@ models:
       - name: o_orderkey_seq
         description: "duplicate seq column to test UK"
     tests:
+      # This constraint should be skipped because it has failures
       - dbt_constraints.primary_key:
           column_name: o_orderkey
           config:
             severity: warn
+      # This constraint should be still generated because always_create_constraint=true
+      - dbt_constraints.unique_key:
+          column_name: o_orderkey
+          config:
+            warn_if: ">= 5000"
+            error_if: ">= 10000"
+            always_create_constraint: true
+      # This constraint should be still generated because always_create_constraint=true
       - dbt_constraints.unique_key:
           column_name: o_orderkey_seq
           config:
             severity: warn
+            always_create_constraint: true
 
   - name: fact_order_line_missing_orders
     description: "Test that we do not create FK on failed tests"

--- a/macros/create_constraints.sql
+++ b/macros/create_constraints.sql
@@ -168,14 +168,14 @@
     {#- Loop through the results and find all tests that passed and match the constraint_types -#}
     {#- Issue #2: added condition that the where config must be empty -#}
     {%- for res in results
-        if res.status == "pass"
-            and res.node.config.materialized == "test"
+        if res.node.config.materialized == "test"
+            and res.status in ("pass", "warn")
             and res.node.test_metadata
             and res.node.test_metadata.name is in( constraint_types )
-            and res.failures == 0
-            and res.node.config.error_if == '!= 0'
-            and res.node.config.warn_if == '!= 0'
-            and res.node.config.where is none -%}
+            and ( res.failures == 0 or
+                  res.node.config.get("always_create_constraint", false) )
+            and ( res.node.config.where is none or
+                  res.node.config.get("always_create_constraint", false) )  -%}
 
         {%- set test_model = res.node -%}
         {%- set test_parameters = test_model.test_metadata.kwargs -%}


### PR DESCRIPTION
This should address several open feature requests. Until now there was no way to force a constraint to be generated when there was a `where` configuration or if the constraint has a threshold. Now a `always_create_constraint` configuration setting will override those exclusions. 

PLEASE NOTE: 
* You will get an error if you try to force constraints that are enforced by your database. On Snowflake that is a not_null constraint but on databases like Oracle, all the constraints are enforce. 
* This feature can all cause unexpected query results on Snowflake due to join elimination. Some users specifically requested that they could have the benefits of join elimination where there was a missing parent 0 or -1 record. Personally, I would the parent to have a 0 or -1 record but I understand there are scenarios for data vault that would benefit from this feature.

This is an example from the integration tests using the feature:
```yml
  - name: dim_duplicate_orders
    description: "Test that we do not try to create PK/UK on failed tests"
    columns:
      - name: o_orderkey
        description: "The primary key for this table"
      - name: o_orderkey_seq
        description: "duplicate seq column to test UK"
    tests:
      # This constraint should be skipped because it has failures
      - dbt_constraints.primary_key:
          column_name: o_orderkey
          config:
            severity: warn
      # This constraint should be still generated because always_create_constraint=true
      - dbt_constraints.unique_key:
          column_name: o_orderkey
          config:
            warn_if: ">= 5000"
            error_if: ">= 10000"
            always_create_constraint: true
      # This constraint should be still generated because always_create_constraint=true
      - dbt_constraints.unique_key:
          column_name: o_orderkey_seq
          config:
            severity: warn
            always_create_constraint: true
```